### PR TITLE
Draft: version avec vecteurs dépendants (NE PAS MERGE)

### DIFF
--- a/theories/interpreter.v
+++ b/theories/interpreter.v
@@ -58,14 +58,14 @@ Section recalg_coq.
    (*  We renamed "a" into "k" to avoid name clash on Sa between
        ra_compute and Cn_compute at Extraction, which generates
        a fresh new name like "sa0", not so nice at display *)
-  Fixpoint ra_compute k (Sk : recalg k) : ∀Vk : vec nat k, computable (⟦Sk⟧ Vk) :=
+  Fixpoint ra_compute {k} (Sk : recalg k) : ∀Vk : vec nat k, computable (⟦Sk⟧ Vk) :=
     match Sk with
     | ra_zero         => Zr_compute
     | ra_succ         => Sc_compute
     | ra_proj i       => Id_compute i
-    | ra_comp Sb Skb  => Cn_compute ra_compute Sb Skb
-    | ra_prec Sb Sb'' => Pr_compute ra_compute Sb Sb''
-    | ra_umin Sb'     => Mn_compute ra_compute Sb'
+    | ra_comp Sb Skb  => Cn_compute (ra_compute Sb) (vec_hmap ra_compute Skb)
+    | ra_prec Sb Sb'' => Pr_compute (ra_compute Sb) (ra_compute Sb'')
+    | ra_umin Sb'     => Mn_compute (ra_compute Sb')
     end.
 
 End recalg_coq.
@@ -91,6 +91,8 @@ Print Assumptions ra_compute.
 Check coq_is_total.
 Print Assumptions coq_is_total.
 
+Recursive Extraction ra_compute.
+
 Extraction Inline vec_S_inv.
 Extraction Inline sig_monotonic comp reify.
 Extraction Inline umin₀_compute.
@@ -108,14 +110,18 @@ Extraction Implicit idx_nxt [n].
 Extraction Implicit vec         [1].
 Extraction Implicit vec_cons    [n].
 Extraction Implicit vec_prj     [n].
-
+Extraction Implicit hvec        [n 1 2].
+Extraction Implicit hvec_nil    [ ].
+Extraction Implicit hvec_cons    [n x v ].
+ 
 Extraction Implicit recalg      [1].
 Extraction Implicit ra_proj     [a].
 Extraction Implicit ra_comp     [a b].
 Extraction Implicit ra_prec     [a].
 Extraction Implicit ra_umin     [a].
 
-Extraction Implicit vec_map_compute [a].
+Extraction Implicit vec_hmap [P n].
+Extraction Implicit hvec_map_compute [C X Y F b v].
 Extraction Implicit Id_compute [a].
 
 Extraction Implicit ra_compute [k].

--- a/theories/vec.v
+++ b/theories/vec.v
@@ -158,3 +158,25 @@ End vec_map.
 
 Notation "⟨ x ⟩" :=  (x ∷ ⟨⟩) (at level 0, format "⟨ x ⟩").
 Notation "⟨ x ; y ; .. ; z ⟩" :=  (x ∷ (y ∷ .. (z ∷ ⟨⟩) ..)) (at level 0, format "⟨ x ; y ; .. ; z ⟩").
+
+Section hvec.
+
+  Variables (X : Type) (P : X → Type).
+
+  Inductive hvec : forall {n}, vec X n → Type :=
+    | hvec_nil : hvec ⟨⟩
+    | hvec_cons {n x v} : P x → @hvec n v → hvec (x ∷ v).
+
+  Definition vec_hmap (f : forall x, P x) : ∀ {n} v, @hvec n v :=
+    fix loop {n} v :=
+      match v with
+      | ⟨⟩    => hvec_nil
+      | x ∷ v => hvec_cons (f x) (loop v)
+      end.
+
+End hvec.
+
+Arguments hvec {_} P {_}.
+Arguments hvec_nil {_ _}.
+Arguments hvec_cons {_ _ _ _ _}.
+Arguments vec_hmap {X P} _ {n} _.


### PR DESCRIPTION
Salut JF,

Voici une version avec des vecteurs dépendants `hvec` qui évite les commutatives-cut
le mieux possible. Pour info. NE PAS MERGE 