### PR TITLE
names of hypotheses made more systematic

### DIFF
--- a/theories/compute.v
+++ b/theories/compute.v
@@ -28,34 +28,34 @@ Section Cn_compute.
 
   Section Cn_props.
 
-    Variables (Va : vec nat a) (cVa : ex (Cn ⟦Sb⟧ (vec_map ra_sem Sab) Va)).
+    Variables (Va : vec nat a) (dVa : ex (Cn ⟦Sb⟧ (vec_map ra_sem Sab) Va)).
 
     Local Fact Cn_p1 : ∃Vb, ∀i, ⟦Sab.[i]⟧ Va Vb.[i].
     Proof.
-      destruct cVa as (y & Vb & H1 & H2).
+      destruct dVa as (y & Vb & H1 & H2).
       exists Vb; intros i.
       specialize (H2 i).
       now rewrite vec_prj_map in H2.
     Qed.
 
-    Variables (Vb : vec nat b) (HVb : ∀i, ⟦Sab.[i]⟧ Va Vb.[i]).
+    Variables (Vb : vec nat b) (Va_Vb : ∀i, ⟦Sab.[i]⟧ Va Vb.[i]).
 
     Fact Cn_p2 : ∃y, ⟦Sb⟧ Vb y.
     Proof.
-      destruct cVa as (y & Wb & H1 & H2).
+      destruct dVa as (y & Wb & H1 & H2).
       exists y.
       replace Vb with Wb; trivial.
       apply vec_prj_ext; intros i.
-      specialize (H2 i); specialize (HVb i).
+      specialize (H2 i); specialize (Va_Vb i).
       rewrite vec_prj_map in H2.
-      revert H2 HVb; apply ra_sem_fun.
+      revert H2 Va_Vb; apply ra_sem_fun.
     Qed.
 
-    Variables (y : nat) (Hy : ⟦Sb⟧ Vb y).
+    Variables (y : nat) (Vb_y : ⟦Sb⟧ Vb y).
 
     Fact Cn_p3 : ⟦ra_comp Sb Sab⟧ Va y.
     Proof.
-      exists Vb; refine (conj Hy _).
+      exists Vb; refine (conj Vb_y _).
       intro; now rewrite vec_prj_map.
     Qed.
 
@@ -66,9 +66,9 @@ Section Cn_compute.
   Arguments Cn_p3 {_} {_} _ {_}.
 
   Definition Cn_compute : ∀Va, compute (Cn ⟦Sb⟧ (vec_map ra_sem Sab) Va) :=
-    λ Va cVa, let (Vb,cVb) := cSab Va (Cn_p1 cVa) in
-              let (y,cy)   := cSb Vb (Cn_p2 cVa cVb) in
-              ⟪y, Cn_p3 cVb cy⟫.
+    λ Va dVa, let (Vb, Va_Vb) := cSab Va (Cn_p1 dVa) in
+              let (y, Vb_y)   := cSb Vb (Cn_p2 dVa Va_Vb) in
+              ⟪y, Cn_p3 Va_Vb Vb_y⟫.
 
 End Cn_compute.
 
@@ -83,7 +83,7 @@ Section Pr_compute.
   Definition Pr_compute : ∀Va', compute (Pr ⟦Sa⟧ ⟦Sa''⟧ Va') :=
     vec_S_inv (λ z Va,
       prim_rec_compute (ra_sem_fun _)
-                       (λ V cV, cSa V cV)
+                       (λ V dV, cSa V dV)
                        (λ _ _ _, ra_sem_fun _ _)
                        (λ V n x cVnx, cSa'' (n ∷ x ∷ V) cVnx)
                        Va
@@ -100,7 +100,7 @@ Section Mn_compute.
 
   Definition Mn_compute Va : compute (Mn ⟦Sa'⟧ Va) :=
     umin₀_compute (λ _, ra_sem_fun _ _)
-                  (λ n cn, cSa' (n ∷ Va) cn).
+                  (λ n dn, cSa' (n ∷ Va) dn).
 
 End Mn_compute.
 

--- a/theories/interpreter.v
+++ b/theories/interpreter.v
@@ -67,7 +67,7 @@ Section recalg_coq.
     | ra_zero         => Zr_compute
     | ra_succ         => Sc_compute
     | ra_proj i       => Id_compute i
-    | ra_comp Sb Sab  => Cn_compute ⟦Sb⟧ₒ (λ Va cVa, vec_map_compute (λ Sa, ⟦Sa⟧ₒ Va) Sab cVa)
+    | ra_comp Sb Sab  => Cn_compute ⟦Sb⟧ₒ (λ Va dVa, vec_map_compute (λ Sa, ⟦Sa⟧ₒ Va) Sab dVa)
     | ra_prec Sb Sb'' => Pr_compute ⟦Sb⟧ₒ ⟦Sb''⟧ₒ
     | ra_umin Sb'     => Mn_compute ⟦Sb'⟧ₒ
     end

--- a/theories/prim_rec_compute.v
+++ b/theories/prim_rec_compute.v
@@ -26,11 +26,11 @@ Section prec_compute.
 
   Section prim_rec_compute_props.
 
-    Variables (n : nat) (e : ∃y, prim_rec F G x (S n) y).
+    Variables (n : nat) (d : ∃y, prim_rec F G x (S n) y).
 
     Local Fact prc_TC1 : ∃y, prim_rec F G x n y.
     Proof.
-      destruct e as (? & yn₁ & ? & ?).
+      destruct d as (? & yn₁ & ? & ?).
       now exists yn₁.
     Qed.
 
@@ -38,7 +38,7 @@ Section prec_compute.
 
     Local Fact prc_TC2 : ∃y, G x n yn y.
     Proof.
-      destruct e as (yn₁' & yn₁ & Hyn₁ & Hyn₁').
+      destruct d as (yn₁' & yn₁ & Hyn₁ & Hyn₁').
       exists yn₁'.
       now rewrite <- (prim_rec_fun Ffun Gfun Hyn₁ Hyn).
     Qed.
@@ -56,9 +56,9 @@ Section prec_compute.
 
   Fixpoint prim_rec_compute m : compute (prim_rec F G x m) :=
     match m with
-      | 0   => λ e, Fcomp x e
-      | S n => λ e, let (yn , y_yn)   := prim_rec_compute n (prc_TC1 e) in
-                    let (yn', yn_yn') := Gcomp x n yn (prc_TC2 e y_yn) in
+      | 0   => λ d, Fcomp x d
+      | S n => λ d, let (yn , y_yn)   := prim_rec_compute n (prc_TC1 d) in
+                    let (yn', yn_yn') := Gcomp x n yn (prc_TC2 d y_yn) in
                     ⟪yn', prc_PO1 y_yn yn_yn'⟫
     end.
 


### PR DESCRIPTION
2 files slightly modified in order to follow the more systematic naming scheme used in other files:
- e.g., a hypothesis linking Va to Vb is named Va_Vb instead of HVb
- domain hypotheses start with d (instead of e or c)